### PR TITLE
450 bitwarden access

### DIFF
--- a/otterdog/eclipse-pass.jsonnet
+++ b/otterdog/eclipse-pass.jsonnet
@@ -21,6 +21,12 @@ orgs.newOrg('eclipse-pass') {
     },
   ],
   secrets+: [
+    orgs.newOrgSecret('HELLO_WORLD_QUEST') {
+      value: "bitwarden:23801ca4-fd27-446c-b5af-b07b0108f443@quest",
+    },
+    orgs.newOrgSecret('HELLO_WORLD_COLOR') {
+      value: "bitwarden:23801ca4-fd27-446c-b5af-b07b0108f443@color",
+    },
     orgs.newOrgSecret('GH_PAT') {
       value: "********",
     },

--- a/otterdog/eclipse-pass.jsonnet
+++ b/otterdog/eclipse-pass.jsonnet
@@ -15,6 +15,11 @@ orgs.newOrg('eclipse-pass') {
       default_workflow_permissions: "write",
     },
   },
+  credentials+: [{
+      "provider": "bitwarden",
+      "item_id" : "23801ca4-fd27-446c-b5af-b07b0108f443"
+    },
+  ],
   secrets+: [
     orgs.newOrgSecret('GH_PAT') {
       value: "********",

--- a/otterdog/eclipse-pass.jsonnet
+++ b/otterdog/eclipse-pass.jsonnet
@@ -15,17 +15,12 @@ orgs.newOrg('eclipse-pass') {
       default_workflow_permissions: "write",
     },
   },
-  credentials+: [{
-      "provider": "bitwarden",
-      "item_id" : "23801ca4-fd27-446c-b5af-b07b0108f443"
-    },
-  ],
   secrets+: [
     orgs.newOrgSecret('HELLO_WORLD_QUEST') {
-      value: "bitwarden:23801ca4-fd27-446c-b5af-b07b0108f443@quest",
+      value: "pass:bots/technology.pass/helloworld/quest",
     },
     orgs.newOrgSecret('HELLO_WORLD_COLOR') {
-      value: "bitwarden:23801ca4-fd27-446c-b5af-b07b0108f443@color",
+      value: "pass:bots/technology.pass/helloworld/color",
     },
     orgs.newOrgSecret('GH_PAT') {
       value: "********",


### PR DESCRIPTION

Based on
https://gitlab.eclipse.org/eclipsefdn/security/otterdog#bitwarden

We want to store the credentials like

```
"organizations": [
  {
    "name": "<org name>",
    "github_id": "<github org id>",
    "credentials": {
      "provider": "bitwarden",
      "item_id" : "<bitwarden item id>"
    }
  }
]
```

Two problems I believe

1) I think `credentials` should be a list, not an object, so

```
"organizations": [
  {
    "name": "<org name>",
    "github_id": "<github org id>",
    "credentials": [{
      "provider": "bitwarden",
      "item_id" : "<bitwarden item id>"
    }]
  }
]
```

and

2) I think we should add via jsonnet, so more like

```
orgs.newOrg('eclipse-pass') {
  credentials+: [{
      "provider": "bitwarden",
      "item_id" : "23801ca4-fd27-446c-b5af-b07b0108f443"
    },
  ],
}
```

We then also added those as GitHub org secrets based on [organization secrets documentation](https://otterdog.readthedocs.io/en/latest/reference/organization/secret/)

```javascript
orgs.newOrg('eclipse-pass') {
  secrets+: [
    orgs.newOrgSecret('HELLO_WORLD_QUEST') {
      value: "bitwarden:23801ca4-fd27-446c-b5af-b07b0108f443@quest",
    },
    orgs.newOrgSecret('HELLO_WORLD_COLOR') {
      value: "bitwarden:23801ca4-fd27-446c-b5af-b07b0108f443@color",
    },
  ],
}

