### PR TITLE
Add Configuration to PASS-Documentation

### DIFF
--- a/otterdog/eclipse-pass.jsonnet
+++ b/otterdog/eclipse-pass.jsonnet
@@ -300,6 +300,15 @@ orgs.newOrg('eclipse-pass') {
       },
     },
     orgs.newRepo('pass-documentation') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      description: "PASS Documentation",
+      dependabot_alerts_enabled: true,
+      dependabot_security_updates_enabled: true,
+      secret_scanning: "disabled",
+      secret_scanning_push_protection: "disabled",
+      web_commit_signoff_required: false,
     },
     orgs.newRepo('pass-doi-service') {
       allow_merge_commit: true,

--- a/otterdog/eclipse-pass.jsonnet
+++ b/otterdog/eclipse-pass.jsonnet
@@ -306,8 +306,8 @@ orgs.newOrg('eclipse-pass') {
       description: "PASS Documentation",
       dependabot_alerts_enabled: true,
       dependabot_security_updates_enabled: true,
-      secret_scanning: "disabled",
-      secret_scanning_push_protection: "disabled",
+      secret_scanning: "enabled",
+      secret_scanning_push_protection: "enabled",
       web_commit_signoff_required: false,
     },
     orgs.newRepo('pass-doi-service') {


### PR DESCRIPTION
This change will add the initial configuration to the PASS-Documentation repository. The configuration was mirrored from our other repositories to be aligned with those repositories settings.