### PR TITLE
Archive pass-auth

### DIFF
--- a/otterdog/eclipse-pass.jsonnet
+++ b/otterdog/eclipse-pass.jsonnet
@@ -134,6 +134,7 @@ orgs.newOrg('eclipse-pass') {
     orgs.newRepo('pass-auth') {
       allow_merge_commit: true,
       allow_update_branch: false,
+      archived: true,
       delete_branch_on_merge: false,
       dependabot_alerts_enabled: false,
       web_commit_signoff_required: false,


### PR DESCRIPTION
The pass-auth repository is no longer user and should be archived.