### PR TITLE
Add technology-pass-security to security_managers

### DIFF
--- a/otterdog/eclipse-pass.jsonnet
+++ b/otterdog/eclipse-pass.jsonnet
@@ -5,7 +5,7 @@ orgs.newOrg('eclipse-pass') {
     description: "",
     name: "Eclipse Pass",
     packages_containers_internal: false,
-     security_managers: [
+    security_managers: [
         "eclipsefdn-security",
         "technology-pass-security"
     ],

--- a/otterdog/eclipse-pass.jsonnet
+++ b/otterdog/eclipse-pass.jsonnet
@@ -5,6 +5,10 @@ orgs.newOrg('eclipse-pass') {
     description: "",
     name: "Eclipse Pass",
     packages_containers_internal: false,
+     security_managers: [
+        "eclipsefdn-security",
+        "technology-pass-security"
+    ],
     web_commit_signoff_required: false,
     workflows+: {
       actions_can_approve_pull_request_reviews: false,

--- a/otterdog/eclipse-pass.jsonnet
+++ b/otterdog/eclipse-pass.jsonnet
@@ -5,9 +5,8 @@ orgs.newOrg('eclipse-pass') {
     description: "",
     name: "Eclipse Pass",
     packages_containers_internal: false,
-    security_managers: [
-        "eclipsefdn-security",
-        "technology-pass-security"
+    security_managers+: [
+      "technology-pass-security"
     ],
     web_commit_signoff_required: false,
     workflows+: {


### PR DESCRIPTION
Adds the technology-pass-security group to the security_managers array so the members of technology-pass-security can see Secret scanning in each pass repo.

See EF ticket https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/5428 for reference.